### PR TITLE
Do not resolve dependencies on import (by default)

### DIFF
--- a/docs/topics/pakku-import.md
+++ b/docs/topics/pakku-import.md
@@ -16,6 +16,9 @@ Import modpack
 
 <snippet id="snippet-options">
 
+`-D`, `--deps`
+: Resolve dependencies after import
+
 `-h`, `--help`
 : Show this message and exit
 

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Import.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Import.kt
@@ -3,6 +3,8 @@ package teksturepako.pakku.cli.cmd
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 import com.github.michaelbull.result.getOrElse
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -22,6 +24,7 @@ import teksturepako.pakku.cli.ui.promptForProject
 class Import : CliktCommand("Import modpack")
 {
     private val pathArg: String by argument("path")
+    private val depsFlag: Boolean by option("-D", "--deps", help = "Resolve dependencies").flag()
 
     override fun run() = runBlocking {
         val modpackModel = importModpackModel(pathArg).getOrElse {
@@ -59,7 +62,7 @@ class Import : CliktCommand("Import modpack")
                     },
                     onSuccess = { project, _, reqHandlers ->
                         lockFile.add(project)
-                        project.resolveDependencies(terminal, reqHandlers, lockFile, projectProvider, platforms)
+                        if (depsFlag) project.resolveDependencies(terminal, reqHandlers, lockFile, projectProvider, platforms)
                         terminal.success(prefixed("${project.getFlavoredSlug()} added"))
                         Modrinth.checkRateLimit()
                     },


### PR DESCRIPTION
Currently, when importing a modpack, it resolves dependencies.

I think this shouldn't be the default behaviour for various reasons:

1. When importing a project, I generally want it to be just as it was published, not with modified dependencies
2. The bigger issue is that mods like [Had Enough Items](https://www.curseforge.com/minecraft/mc-mods/had-enough-items), [Extended Crafting: Nomifactory Edition](https://www.curseforge.com/minecraft/mc-mods/extended-crafting-nomifactory-edition) [and](https://www.curseforge.com/minecraft/mc-mods/ae2-extended-life) [a](https://www.curseforge.com/minecraft/mc-mods/dank-null-no_rce) [lot](https://www.curseforge.com/minecraft/mc-mods/mekanism-ce) [more](https://modrinth.com/mod/alfheim-lighting-engine) exist, which are maintained forks of various big mods, but for older game versions. Usually, the big mods are referenced in the dependencies of other mods, which causes issues if a modpack ships the fork, instead of the original mod.

Additionally, someone might actually want to resolve dependencies, that's why there now is a --deps/-D switch, which resolves dependencies, just like it did before.

Another option would be to keep the default behaviour and invert the switch, but as stated, I think the default should be changed.