### PR TITLE
Add "Updated" section to diff

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -12,6 +12,7 @@
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
       <option name="KEEP_LINE_BREAKS" value="false" />
+      <option name="ELSE_ON_NEW_LINE" value="true" />
       <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
     </codeStyleSettings>
   </code_scheme>

--- a/docs/topics/pakku-diff.md
+++ b/docs/topics/pakku-diff.md
@@ -22,7 +22,7 @@ Diff projects in modpack
 `--markdown`
 : Export a `.md` file formatted as regular markdown
 
-`--detailed-update`
+`-v`, `--verbose`
 : Display detailed information which version of a project was updated to which version
 
 `-h`, `--help`

--- a/docs/topics/pakku-diff.md
+++ b/docs/topics/pakku-diff.md
@@ -22,6 +22,9 @@ Diff projects in modpack
 `--markdown`
 : Export a `.md` file formatted as regular markdown
 
+`--detailed-update`
+: Display detailed information which version of a project was updated to which version
+
 `-h`, `--help`
 : Show this message and exit
 

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Diff.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Diff.kt
@@ -79,11 +79,17 @@ class Diff : CliktCommand("Diff projects in modpack")
                 /** On multiloader modpacks, the mod might have been added for another loader, causing the
                  * files key to have changed without an actual update.
                  **/
-                if (oldProjectFiles.firstOrNull()?.hashes?.get("sha1") == newProjectFiles.firstOrNull()?.hashes?.get("sha1")) continue
+                val oldFileHash = oldProjectFiles.firstOrNull()?.hashes?.get("sha1")
+                val newFileHash = newProjectFiles.firstOrNull()?.hashes?.get("sha1")
+                if (oldFileHash == newFileHash) continue
+
                 if (verboseOpt)
                 {
-                    verboseUpdatedFiles["${oldProjectFiles.firstOrNull()?.fileName}"] =
-                        "${newProjectFiles.firstOrNull()?.fileName}"
+                    val oldFileName = oldProjectFiles.firstOrNull()?.fileName
+                    val newFileName = newProjectFiles.firstOrNull()?.fileName
+                    val fileNamesNotNullOrEmpty = !oldFileName.isNullOrEmpty() && !newFileName.isNullOrEmpty()
+
+                    if (fileNamesNotNullOrEmpty) verboseUpdatedFiles["$oldFileName"] = "$newFileName"
                 }
                 else
                 {

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Diff.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Diff.kt
@@ -38,7 +38,8 @@ class Diff : CliktCommand("Diff projects in modpack")
             if (allOldProjects containsNotProject newProject)
             {
                 newProject
-            } else null
+            }
+            else null
         }.mapNotNull { it.name.values.firstOrNull() }
         added.forEach { terminal.success("+ $it") }
 
@@ -46,13 +47,15 @@ class Diff : CliktCommand("Diff projects in modpack")
             if (allNewProjects containsNotProject oldProject)
             {
                 oldProject
-            } else null
+            }
+            else null
         }.mapNotNull { it.name.values.firstOrNull() }
         removed.forEach { terminal.danger("- $it") }
 
         val updated: MutableList<String> = mutableListOf()
         val oldFiles: MutableList<String> = mutableListOf()
         val newFiles: MutableList<String> = mutableListOf()
+
         for (oldProject in allOldProjects)
         {
             /** We only care about projects, which previously also existed **/
@@ -137,7 +140,6 @@ class Diff : CliktCommand("Diff projects in modpack")
                 updated.forEach { file.appendText("- $it\n") }
             }
         }
-
         echo()
     }
 }

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Diff.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Diff.kt
@@ -13,11 +13,17 @@ import java.io.File
 
 class Diff : CliktCommand("Diff projects in modpack")
 {
-    private val oldPathArg by argument("path")
-    private val newPathArg by argument("path")
-    private val markdownDiffOpt by option("--markdown-diff", metavar = "<path>", help = "Export a `.md` file formatted as a diff code block")
-    private val markdownOpt by option("--markdown", metavar = "<path>", help = "Export a `.md` file formatted as regular markdown")
-    private val detailedUpdate: Boolean by option("--detailed-update", help = "Gives detailed information on which mods were updated").flag()
+    private val oldPathArg by argument("old-lock-file")
+    private val newPathArg by argument("current-lock-file")
+    private val markdownDiffOpt by option(
+        "--markdown-diff", metavar = "<path>", help = "Export a `.md` file formatted as a diff code block"
+    )
+    private val markdownOpt by option(
+        "--markdown", metavar = "<path>", help = "Export a `.md` file formatted as regular markdown"
+    )
+    private val verboseOpt: Boolean by option(
+        "-v", "--verbose", help = "Gives detailed information on which mods were updated"
+    ).flag()
 
     override fun run(): Unit = runBlocking {
         val oldLockFile = LockFile.readToResultFrom(oldPathArg).getOrElse {
@@ -76,7 +82,7 @@ class Diff : CliktCommand("Diff projects in modpack")
                              **/
                             if (oldProjectFiles.firstOrNull()?.hashes?.get("sha1") != newProjectFiles.firstOrNull()?.hashes?.get("sha1")                            )
                             {
-                                if (detailedUpdate)
+                                if (verboseOpt)
                                 {
                                     oldFiles.add("${oldProjectFiles.firstOrNull()?.fileName}")
                                     newFiles.add("${newProjectFiles.firstOrNull()?.fileName}")
@@ -90,7 +96,8 @@ class Diff : CliktCommand("Diff projects in modpack")
                 }
             }
         }
-        if (detailedUpdate)
+
+        if (verboseOpt)
         {
             val maxOldFileLength = oldFiles.maxOfOrNull { it.length } ?: 0
             for (i in oldFiles.indices)

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Diff.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Diff.kt
@@ -3,10 +3,12 @@ package teksturepako.pakku.cli.cmd
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import kotlinx.coroutines.runBlocking
 import teksturepako.pakku.api.data.LockFile
 import teksturepako.pakku.api.projects.containsNotProject
+import teksturepako.pakku.api.projects.containsProject
 import java.io.File
 
 class Diff : CliktCommand("Diff projects in modpack")
@@ -15,6 +17,7 @@ class Diff : CliktCommand("Diff projects in modpack")
     private val newPathArg by argument("path")
     private val markdownDiffOpt by option("--markdown-diff", metavar = "<path>", help = "Export a `.md` file formatted as a diff code block")
     private val markdownOpt by option("--markdown", metavar = "<path>", help = "Export a `.md` file formatted as regular markdown")
+    private val detailedUpdate: Boolean by option("--detailed-update", help = "Gives detailed information on which mods were updated").flag()
 
     override fun run(): Unit = runBlocking {
         val oldLockFile = LockFile.readToResultFrom(oldPathArg).getOrElse {
@@ -22,36 +25,80 @@ class Diff : CliktCommand("Diff projects in modpack")
             echo()
             return@runBlocking
         }
+        val allOldProjects = oldLockFile.getAllProjects()
 
         val newLockFile = LockFile.readToResultFrom(newPathArg).getOrElse {
             terminal.danger(it.message)
             echo()
             return@runBlocking
         }
+        val allNewProjects = newLockFile.getAllProjects()
 
-        val added = newLockFile.getAllProjects()
-            .mapNotNull { newProject ->
-                if (oldLockFile.getAllProjects() containsNotProject newProject)
-                {
-                    newProject
-                }
-                else null
-            }
-            .mapNotNull { it.name.values.firstOrNull() }
-
+        val added = allNewProjects.mapNotNull { newProject ->
+            if (allOldProjects containsNotProject newProject)
+            {
+                newProject
+            } else null
+        }.mapNotNull { it.name.values.firstOrNull() }
         added.forEach { terminal.success("+ $it") }
 
-        val removed = oldLockFile.getAllProjects()
-            .mapNotNull { oldProject ->
-                if (newLockFile.getAllProjects() containsNotProject oldProject)
-                {
-                    oldProject
-                }
-                else null
-            }
-            .mapNotNull { it.name.values.firstOrNull() }
-
+        val removed = allOldProjects.mapNotNull { oldProject ->
+            if (allNewProjects containsNotProject oldProject)
+            {
+                oldProject
+            } else null
+        }.mapNotNull { it.name.values.firstOrNull() }
         removed.forEach { terminal.danger("- $it") }
+
+        val updated: MutableList<String> = mutableListOf()
+        val oldFiles: MutableList<String> = mutableListOf()
+        val newFiles: MutableList<String> = mutableListOf()
+        for (oldProject in allOldProjects)
+        {
+            /** We only care about projects, which previously also existed **/
+            if (allNewProjects containsProject oldProject)
+            {
+                for (newProject in allNewProjects)
+                {
+                    /** Everything inside if-block is the same project **/
+                    if (newProject isAlmostTheSameAs oldProject)
+                    {
+                        val oldProjectFiles = oldProject.files
+                        val newProjectFiles = newProject.files
+                        /** If the project files are not identical, means that files have changed **/
+                        if (oldProjectFiles != newProjectFiles)
+                        {
+                            /** On multiloader modpacks, the mod might have been added for another loader, causing the
+                             * files key to have changed without an actual update
+                             **/
+                            if (oldProjectFiles.firstOrNull()?.hashes?.get("sha1") != newProjectFiles.firstOrNull()?.hashes?.get("sha1")                            )
+                            {
+                                if (detailedUpdate)
+                                {
+                                    oldFiles.add("${oldProjectFiles.firstOrNull()?.fileName}")
+                                    newFiles.add("${newProjectFiles.firstOrNull()?.fileName}")
+                                } else
+                                {
+                                    updated.add("${oldProject.name.values.firstOrNull()}")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (detailedUpdate)
+        {
+            val maxOldFileLength = oldFiles.maxOfOrNull { it.length } ?: 0
+            for (i in oldFiles.indices)
+            {
+                val oldFileName = oldFiles[i]
+                val newFileName = newFiles[i]
+                updated.add("${oldFileName.padEnd(maxOldFileLength)} -> $newFileName")
+            }
+        }
+
+        updated.forEach { terminal.info("! $it") }
 
         if (markdownDiffOpt != null)
         {
@@ -62,6 +109,7 @@ class Diff : CliktCommand("Diff projects in modpack")
             file.appendText("```diff\n")
             added.forEach { file.appendText("+ $it\n") }
             removed.forEach { file.appendText("- $it\n") }
+            updated.forEach { file.appendText("! $it\n") }
             file.appendText("```\n")
         }
 
@@ -73,14 +121,20 @@ class Diff : CliktCommand("Diff projects in modpack")
             file.outputStream().close()
             if (added.isNotEmpty())
             {
-                file.appendText("### Added\n\n")
+                file.appendText("### Added\n")
                 added.forEach { file.appendText("- $it\n") }
                 if (removed.isNotEmpty()) file.appendText("\n")
             }
             if (removed.isNotEmpty())
             {
-                file.appendText("### Removed\n\n")
+                file.appendText("### Removed\n")
                 removed.forEach { file.appendText("- $it\n") }
+                if (updated.isNotEmpty()) file.appendText("\n")
+            }
+            if (updated.isNotEmpty())
+            {
+                file.appendText("### Updated\n")
+                updated.forEach { file.appendText("- $it\n") }
             }
         }
 


### PR DESCRIPTION
Added a new "Updated" section to the diff command saying which projects were updated and optionally, using --detailed-update to which version.

Also, I've removed the newlines after the ### since IMO it looks better when looking at the plaintext file and the markdown renderer doesn't care about it anyway.

I don't know how or if you want comments inside the code, but I added some as this was somewhat confusing.

*This is probably not the prettiest or fastest solution, but I don't have the knowledge on how I would do this instead.*

```bash
java -jar pakku.jar diff pakku-lock-old.json pakku-lock.json --markdown changes.md --detailed-update
```

Output looks like this:

Markdown:
```md
### Added
- Carry On
- Thaumcraft

### Removed
- Draconic Evolution

### Updated
- Controlling
- Ender IO
- Inventory Tweaks [1.12 only]
```

Markdown Diff:
```diff
+ Carry On
+ Thaumcraft
- Draconic Evolution
! Controlling
! Ender IO
! Inventory Tweaks [1.12 only] 
```

Markdown Detailed:
```md
### Added
- Carry On
- Thaumcraft

### Removed
- Draconic Evolution

### Updated
- Controlling-3.0.10.jar    -> Controlling-3.0.12.4.jar
- EnderIO-1.12.2-5.3.70.jar -> EnderIO-1.12.2-5.3.72.jar
- InventoryTweaks-1.63.jar  -> InventoryTweaks-1.64+dev.151.jar
```

Markdown Detailed Diff:
```diff
+ Carry On
+ Thaumcraft
- Draconic Evolution
! Controlling-3.0.10.jar    -> Controlling-3.0.12.4.jar
! EnderIO-1.12.2-5.3.70.jar -> EnderIO-1.12.2-5.3.72.jar
! InventoryTweaks-1.63.jar  -> InventoryTweaks-1.64+dev.151.jar
```