### PR TITLE
feat: update need newer file

### DIFF
--- a/src/commonMain/kotlin/teksturepako/pakku/InstantIso8601Serializer.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/InstantIso8601Serializer.kt
@@ -1,0 +1,32 @@
+package teksturepako.pakku
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.time.Instant
+
+/**
+ * A serializer for [Instant] that uses the ISO 8601 representation.
+ *
+ * JSON example: `"2020-12-09T09:16:56.000124Z"`
+ *
+ * @see Instant.toString
+ * @see Instant.parse
+ */
+object InstantIso8601Serializer : KSerializer<Instant>
+{
+
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("java.time.Instant", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): Instant =
+        Instant.parse(decoder.decodeString())
+
+    override fun serialize(encoder: Encoder, value: Instant) {
+        encoder.encodeString(value.toString())
+    }
+
+}

--- a/src/commonMain/kotlin/teksturepako/pakku/api/actions/update/Update.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/actions/update/Update.kt
@@ -53,10 +53,10 @@ suspend fun updateMultipleProjectsWithFiles(
                     }?.also { accProject ->
                         // Combine projects
                         val accFiles = combinedProjectsToOldFiles[accProject]
-                            ?: return@coroutineScope Err(ActionError("Failed to combine project ${accProject.pakkuId} when updating. Report it to developer."))
-                        val accPublished = accFiles.find { it.type == platform.serialName }?.dataPublished
+                            ?: return@coroutineScope Err(ActionError("Failed to combine project ${accProject.pakkuId} when updating. Report it to Pakku's developer."))
+                        val accPublished = accFiles.find { it.type == platform.serialName }?.datePublished
                         if (accPublished != null && accPublished != Instant.MIN)
-                            newProject.files.removeIf { it.type == platform.serialName && it.dataPublished < accPublished }
+                            newProject.files.removeIf { it.type == platform.serialName && it.datePublished < accPublished }
                         (accProject + newProject).get()
                             ?.copy(files = (newProject.files.take(numberOfFiles) + accProject.files).toMutableSet())
                             ?.let x@{ combinedProject ->

--- a/src/commonMain/kotlin/teksturepako/pakku/api/platforms/CurseForge.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/platforms/CurseForge.kt
@@ -13,6 +13,7 @@ import teksturepako.pakku.debug
 import teksturepako.pakku.debugIfEmpty
 import teksturepako.pakku.io.getEnvOrNull
 import teksturepako.pakku.io.toMurmur2
+import java.time.Instant
 
 @Suppress("MemberVisibilityCanBePrivate")
 object CurseForge : Platform(
@@ -162,6 +163,7 @@ object CurseForge : Platform(
                 .filter { it.relationType == 3 }
                 .map { it.modId.toString() }.toMutableSet(),
             size = this.fileLength,
+            dataPublished = Instant.parse(fileDate)
         ).fetchAlternativeDownloadUrl()
     }
 

--- a/src/commonMain/kotlin/teksturepako/pakku/api/platforms/CurseForge.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/platforms/CurseForge.kt
@@ -163,7 +163,7 @@ object CurseForge : Platform(
                 .filter { it.relationType == 3 }
                 .map { it.modId.toString() }.toMutableSet(),
             size = this.fileLength,
-            dataPublished = Instant.parse(fileDate)
+            datePublished = Instant.parse(fileDate)
         ).fetchAlternativeDownloadUrl()
     }
 

--- a/src/commonMain/kotlin/teksturepako/pakku/api/platforms/GitHub.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/platforms/GitHub.kt
@@ -57,7 +57,7 @@ object GitHub : Http(), Provider
                 hashes = null,
                 requiredDependencies = null,
                 size = asset.size,
-                dataPublished = Instant.parse(publishedAt ?: createdAt)
+                datePublished = Instant.parse(publishedAt ?: createdAt)
             )
         }.asReversed()
     }

--- a/src/commonMain/kotlin/teksturepako/pakku/api/platforms/GitHub.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/platforms/GitHub.kt
@@ -8,6 +8,7 @@ import teksturepako.pakku.api.models.gh.GhRepoModel
 import teksturepako.pakku.api.projects.Project
 import teksturepako.pakku.api.projects.ProjectFile
 import teksturepako.pakku.api.projects.ProjectType
+import java.time.Instant
 
 object GitHub : Http(), Provider
 {
@@ -56,6 +57,7 @@ object GitHub : Http(), Provider
                 hashes = null,
                 requiredDependencies = null,
                 size = asset.size,
+                dataPublished = Instant.parse(publishedAt ?: createdAt)
             )
         }.asReversed()
     }

--- a/src/commonMain/kotlin/teksturepako/pakku/api/platforms/Modrinth.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/platforms/Modrinth.kt
@@ -15,6 +15,7 @@ import teksturepako.pakku.api.models.mr.MrProjectModel
 import teksturepako.pakku.api.models.mr.MrVersionModel
 import teksturepako.pakku.api.projects.*
 import teksturepako.pakku.debugIfEmpty
+import java.time.Instant
 import kotlin.system.exitProcess
 import kotlin.time.Duration.Companion.seconds
 
@@ -167,6 +168,7 @@ object Modrinth : Platform(
                     .filter { "required" in it.dependencyType }
                     .mapNotNull { it.projectId }.toMutableSet(),
                 size = versionFile.size,
+                dataPublished = Instant.parse(this.datePublished)
             )
         }.asReversed() // Reverse to make non source files first
     }

--- a/src/commonMain/kotlin/teksturepako/pakku/api/platforms/Modrinth.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/platforms/Modrinth.kt
@@ -168,7 +168,7 @@ object Modrinth : Platform(
                     .filter { "required" in it.dependencyType }
                     .mapNotNull { it.projectId }.toMutableSet(),
                 size = versionFile.size,
-                dataPublished = Instant.parse(this.datePublished)
+                datePublished = Instant.parse(this.datePublished)
             )
         }.asReversed() // Reverse to make non source files first
     }

--- a/src/commonMain/kotlin/teksturepako/pakku/api/projects/Project.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/projects/Project.kt
@@ -8,6 +8,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.get
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import teksturepako.pakku.InstantIso8601Serializer
 import teksturepako.pakku.api.actions.ActionError
 import teksturepako.pakku.api.actions.ActionError.ProjDiffPLinks
 import teksturepako.pakku.api.actions.ActionError.ProjDiffTypes
@@ -16,6 +17,7 @@ import teksturepako.pakku.api.platforms.Multiplatform
 import teksturepako.pakku.api.platforms.Platform
 import teksturepako.pakku.api.platforms.Provider
 import teksturepako.pakku.io.filterPath
+import java.time.Instant
 
 /**
  * Represents a project. (E.g. a mod, resource pack, shader, etc.)

--- a/src/commonMain/kotlin/teksturepako/pakku/api/projects/ProjectFile.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/projects/ProjectFile.kt
@@ -29,7 +29,7 @@ data class ProjectFile(
     val hashes: MutableMap<String, String>? = null,
     @SerialName("required_dependencies") val requiredDependencies: MutableSet<String>? = null,
     val size: Int = 0,
-    val dataPublished: @Serializable(with = InstantIso8601Serializer::class) Instant = Instant.MIN,
+    @SerialName("data_published") val dataPublished: @Serializable(with = InstantIso8601Serializer::class) Instant = Instant.MIN,
 )
 {
     // -- PARENT --

--- a/src/commonMain/kotlin/teksturepako/pakku/api/projects/ProjectFile.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/projects/ProjectFile.kt
@@ -29,7 +29,7 @@ data class ProjectFile(
     val hashes: MutableMap<String, String>? = null,
     @SerialName("required_dependencies") val requiredDependencies: MutableSet<String>? = null,
     val size: Int = 0,
-    @SerialName("data_published") val dataPublished: @Serializable(with = InstantIso8601Serializer::class) Instant = Instant.MIN,
+    @SerialName("date_published") val dataPublished: @Serializable(with = InstantIso8601Serializer::class) Instant = Instant.MIN,
 )
 {
     // -- PARENT --

--- a/src/commonMain/kotlin/teksturepako/pakku/api/projects/ProjectFile.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/projects/ProjectFile.kt
@@ -29,7 +29,7 @@ data class ProjectFile(
     val hashes: MutableMap<String, String>? = null,
     @SerialName("required_dependencies") val requiredDependencies: MutableSet<String>? = null,
     val size: Int = 0,
-    @SerialName("date_published") val dataPublished: @Serializable(with = InstantIso8601Serializer::class) Instant = Instant.MIN,
+    @SerialName("date_published") val datePublished: @Serializable(with = InstantIso8601Serializer::class) Instant = Instant.MIN,
 )
 {
     // -- PARENT --

--- a/src/commonMain/kotlin/teksturepako/pakku/api/projects/ProjectFile.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/projects/ProjectFile.kt
@@ -3,6 +3,7 @@ package teksturepako.pakku.api.projects
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import teksturepako.pakku.InstantIso8601Serializer
 import teksturepako.pakku.api.actions.ActionError
 import teksturepako.pakku.api.actions.ActionError.HashMismatch
 import teksturepako.pakku.api.actions.ActionError.NoHashes
@@ -11,6 +12,7 @@ import teksturepako.pakku.api.data.LockFile
 import teksturepako.pakku.api.data.workingPath
 import teksturepako.pakku.io.createHash
 import java.nio.file.Path
+import java.time.Instant
 import kotlin.io.path.Path
 
 @Serializable
@@ -27,6 +29,7 @@ data class ProjectFile(
     val hashes: MutableMap<String, String>? = null,
     @SerialName("required_dependencies") val requiredDependencies: MutableSet<String>? = null,
     val size: Int = 0,
+    val dataPublished: @Serializable(with = InstantIso8601Serializer::class) Instant = Instant.MIN,
 )
 {
     // -- PARENT --

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Ls.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Ls.kt
@@ -20,6 +20,7 @@ import teksturepako.pakku.api.data.LockFile
 import teksturepako.pakku.cli.ui.getFlavoredName
 import teksturepako.pakku.cli.ui.getFlavoredSlug
 import teksturepako.pakku.cli.ui.getFlavoredUpdateMsg
+import teksturepako.pakku.cli.ui.pError
 
 class Ls : CliktCommand()
 {
@@ -46,7 +47,7 @@ class Ls : CliktCommand()
                 lockFile.getLoaders(),
                 projects.toMutableSet(), ConfigFile.readOrNull(), numberOfFiles = 1
             ).getOrElse {
-                terminal.danger(it.message())
+                terminal.pError(it)
                 echo()
                 mutableSetOf()
             }

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Ls.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Ls.kt
@@ -10,6 +10,8 @@ import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.mordant.table.grid
 import com.github.ajalt.mordant.terminal.danger
 import com.github.ajalt.mordant.terminal.info
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.getOrThrow
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import teksturepako.pakku.api.actions.update.updateMultipleProjectsWithFiles
@@ -43,7 +45,11 @@ class Ls : CliktCommand()
                 lockFile.getMcVersions(),
                 lockFile.getLoaders(),
                 projects.toMutableSet(), ConfigFile.readOrNull(), numberOfFiles = 1
-            )
+            ).getOrElse {
+                terminal.danger(it.message())
+                echo()
+                mutableSetOf()
+            }
         } else null
 
         terminal.println(grid {

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Status.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Status.kt
@@ -5,6 +5,8 @@ import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.mordant.table.grid
 import com.github.ajalt.mordant.terminal.danger
+import com.github.michaelbull.result.getOrElse
+import com.github.michaelbull.result.getOrThrow
 import kotlinx.coroutines.runBlocking
 import teksturepako.pakku.api.actions.update.updateMultipleProjectsWithFiles
 import teksturepako.pakku.api.data.ConfigFile
@@ -74,7 +76,11 @@ class Status: CliktCommand()
                 currentProjects.toMutableSet(),
                 ConfigFile.readOrNull(),
                 numberOfFiles = 1
-            )
+            ).getOrElse {
+                terminal.danger(it.message())
+                echo()
+                return@runBlocking
+            }
 
         fun projStatus()
         {

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Status.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Status.kt
@@ -10,6 +10,7 @@ import teksturepako.pakku.api.actions.update.updateMultipleProjectsWithFiles
 import teksturepako.pakku.api.data.ConfigFile
 import teksturepako.pakku.api.data.LockFile
 import teksturepako.pakku.api.platforms.Platform
+import teksturepako.pakku.api.platforms.Provider
 import teksturepako.pakku.api.projects.containProject
 import teksturepako.pakku.cli.ui.*
 
@@ -79,11 +80,14 @@ class Status: CliktCommand()
         {
             terminal.println(grid {
                 currentProjects.filter { updatedProjects containProject it }.map { project ->
-                    row(project.getFlavoredSlug(), project.getFlavoredName(terminal.theme))
-
-                    val updatedProject = updatedProjects.find { it isAlmostTheSameAs project }
-                    updatedProject?.run {
-
+                    row(project.getFlavoredSlug(), project.getFlavoredName(terminal.theme)) {
+                        val updatedProject = updatedProjects.find { it isAlmostTheSameAs project }
+                        updatedProject?.run {
+                            for (file in files)
+                            {
+                                cell("${Provider.getProvider(file.type)?.shortName ?: file.type}: ${file.fileName}")
+                            }
+                        }
                     }
                 }
             })

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Status.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Status.kt
@@ -77,7 +77,7 @@ class Status: CliktCommand()
                 ConfigFile.readOrNull(),
                 numberOfFiles = 1
             ).getOrElse {
-                terminal.danger(it.message())
+                terminal.pError(it)
                 echo()
                 return@runBlocking
             }

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Update.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Update.kt
@@ -7,6 +7,8 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.mordant.terminal.danger
+import com.github.michaelbull.result.getOrElse
 import kotlinx.coroutines.runBlocking
 import teksturepako.pakku.api.actions.update.updateMultipleProjectsWithFiles
 import teksturepako.pakku.api.data.ConfigFile
@@ -44,7 +46,11 @@ class Update : CliktCommand()
 
         val updatedProjects = updateMultipleProjectsWithFiles(
             lockFile.getMcVersions(), lockFile.getLoaders(), currentProjects.toMutableSet(), ConfigFile.readOrNull(), numberOfFiles = 1
-        )
+        ).getOrElse {
+            terminal.danger(it.message())
+            echo()
+            return@runBlocking
+        }
 
         for (updatedProject in updatedProjects)
         {

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Update.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Update.kt
@@ -15,6 +15,7 @@ import teksturepako.pakku.api.data.ConfigFile
 import teksturepako.pakku.api.data.LockFile
 import teksturepako.pakku.cli.ui.getFullMsg
 import teksturepako.pakku.cli.ui.pDanger
+import teksturepako.pakku.cli.ui.pError
 import teksturepako.pakku.cli.ui.pSuccess
 
 class Update : CliktCommand()
@@ -47,7 +48,7 @@ class Update : CliktCommand()
         val updatedProjects = updateMultipleProjectsWithFiles(
             lockFile.getMcVersions(), lockFile.getLoaders(), currentProjects.toMutableSet(), ConfigFile.readOrNull(), numberOfFiles = 1
         ).getOrElse {
-            terminal.danger(it.message())
+            terminal.pError(it)
             echo()
             return@runBlocking
         }


### PR DESCRIPTION
When targeting multi loader mods. Some mod has older version that mark as supporting prefer loader sorted by #36 will become the first.
This PR make the update require the files on particular platform newer than the local by recording the publishing date for project files.
