### PR TITLE
docs: Updated docs with Nix installation

### DIFF
--- a/docs/topics/Installing-Pakku.md
+++ b/docs/topics/Installing-Pakku.md
@@ -1,7 +1,8 @@
 # Installing Pakku
 
 You can install Pakku [using Scoop](#install-scoop) for Windows,
-[using Brew](#install-brew) for macOS (or Linux)
+[using Brew](#install-brew) for macOS (or Linux),
+[using nix](#install-nix) for Windows WSL, macOS, Linux
 or [manually](#install-manually).
 
 Pakku also requires Java to be installed on your computer,
@@ -35,6 +36,47 @@ If not, you _can_ install it from [here](https://www.java.com/en/download/).
    ```
    {prompt="$"}
 3. In your modpack folder, run Pakku from your terminal:
+   ```
+   pakku
+   ```
+   {prompt="$"}
+
+</procedure>
+
+<procedure title="Install Pakku using Nix" id="install-nix">
+
+Pakku is available from [nixpkgs](https://github.com/NixOS/nixpkgs) as `pakku`.
+
+1. Check you have Nix installed on your computer. NixOS comes with it preinstalled.
+   If not, check the installation instructions from [here](https://nixos.org/download/) for your OS.
+2. If using just the nix package manager you can install Pakku with these commands:
+   ```nix
+   # without flakes:
+   nix-env -iA nixpkgs.pakku
+   
+   # with flakes:
+   nix profile install nixpkgs#pakku
+   ```
+3. For NixOS and Home Manager you can install by adding `pakku` to your system or user packages.
+   
+   NixOS:
+   ```nix
+   {
+      environment.systemPackages = [
+         pkgs.pakku
+      ];
+   }
+   ```
+   
+   Home Manager:
+   ```nix
+   {
+      home.packages = [
+         pkgs.pakku
+      ];
+   }
+   ```
+4. In your modpack folder, run Pakku from your terminal
    ```
    pakku
    ```


### PR DESCRIPTION
Documentation for installing through Nix. 

> [!WARNING]
> These install methods currently don't work as the PR for Pakku has not gone through Hydra yet.
> Documentation of Nix channel updates is [here](https://wiki.nixos.org/wiki/Channel_branches#Internal_channel_update_process). 

I would suggest not merging this until Pakku is available on both unstable and stable branches and I test to make sure these documents are correct.

Unstable links are below:
- [Nixpkgs - Unstable PR](https://github.com/NixOS/nixpkgs/pull/421153)
- [Nixpkgs PR Tracker - Unstable PR](https://nixpk.gs/pr-tracker.html?pr=421153)
- [Nixpkgs-Tracker - Unstable PR](https://nixpkgs-tracker.ocfox.me/?pr=421153)

Stable links are below:
- [Nixpkgs - Stable PR](https://github.com/NixOS/nixpkgs/pull/422164)
- [Nixpkgs PR Tracker - Stable PR](https://nixpk.gs/pr-tracker.html?pr=422164)
- [Nixpkgs-Tracker - Stable PR](https://nixpkgs-tracker.ocfox.me/?pr=422164)