### PR TITLE
Make Pakku ID predictable

### DIFF
--- a/src/commonMain/kotlin/teksturepako/pakku/api/data/PakkuId.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/data/PakkuId.kt
@@ -1,8 +1,13 @@
 package teksturepako.pakku.api.data
 
-fun generatePakkuId(): String {
+import kotlin.random.Random
+
+fun generatePakkuId(slug: MutableMap<String, String>): String
+{
     val allowedChars = ('A'..'Z') + ('a'..'z') + ('0'..'9')
-    return (1..16)
-        .map { allowedChars.random() }
-        .joinToString("")
+
+    val slugToString = slug.toSortedMap().entries.joinToString("") { "${it.key}=${it.value}" }
+    val seed = Random(slugToString.hashCode())
+
+    return (1..16).map { allowedChars.random(seed) }.joinToString("")
 }

--- a/src/commonMain/kotlin/teksturepako/pakku/api/projects/Project.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/projects/Project.kt
@@ -275,6 +275,6 @@ data class Project(
     init
     {
         // Init Pakku ID
-        if (pakkuId == null) pakkuId = generatePakkuId()
+        if (pakkuId == null) pakkuId = generatePakkuId(slug)
     }
 }

--- a/src/commonTest/kotlin/teksturepako/pakku/PakkuTest.kt
+++ b/src/commonTest/kotlin/teksturepako/pakku/PakkuTest.kt
@@ -49,7 +49,7 @@ open class PakkuTest(
         
         debugMode = this.debug
 
-        testName = this::class.simpleName ?: generatePakkuId()
+        testName = this::class.simpleName ?: generatePakkuId(mutableMapOf("provider" to "slug"))
 
         println("Setting up test: $testName")
 


### PR DESCRIPTION
Makes the Pakku ID use a seed instead of being purely random. The seed is generated from the provider and slug. (Seed format `provider=slug`)

My use case is importing old versions of my modpacks:
1. Import version 1 of a modpack
2. Create a git commit
3. Remove pakku-lock.json
4. Import version 2 of the same modpack
5. Create a git commit
6. ...

While the workflow itself is not be impacted by the old behaviour, a `git diff` does not look very nice when the Pakku ID changes all the time.
If there is a better way to update from an old version to a newer version by importing the zip please let me know, but from my brief test a mod removed in the newer version will not get removed in the pakku-lock.json.

A potential issue of this PR could be an identical slug, if the user adds a project from CurseForge and Modrinth but links them wrongly.
I.E. mod A from CF linked to mod B from MR and mod B from CF linked to mod A from MR.
Or even if mod A from CF is linked to mod A on MR and mod A from CF is also linked to mod B from MR.
I think in both of these situations, the user probably knew exactly what they were doing.

Ideally this could get avoided by using both slugs as the seed, but I think that `add prj --cf A --mr A` seems to not add them *at the same time* but one after the other, generating the project under one provider and later on adding the other provider