### PR TITLE
Remove duplicated description for Server-Side Mod Handling.

### DIFF
--- a/docs/topics/Exporting-a-Modpack.md
+++ b/docs/topics/Exporting-a-Modpack.md
@@ -41,7 +41,7 @@ Example output:
 
 ## Export Without Server Content
 
-> Added in version **1.3.4**
+> Added in version **1.4.0**
 
 Use the `--no-server` option to export a modpack without server-side content:
 
@@ -49,127 +49,14 @@ Use the `--no-server` option to export a modpack without server-side content:
 pakku export --no-server
 ```
 
-### Behavior by Platform
-
-<table>
-<tr>
-<th>Platform</th>
-<th>No Server Export Behavior</th>
-</tr>
-<tr>
-<td><b>CurseForge</b></td>
-<td>No effect - uses standard export behavior</td>
-</tr>
-<tr>
-<td><b>Modrinth</b></td>
-<td>
-<ul>
-<li>Excludes all server-side mods (server-overrides) from the manifest</li>
-<li>Does not export the <code>server-overrides/</code> directory</li>
-<li>Only exports <code>overrides/</code> and <code>client-overrides/</code> directories</li>
-</ul>
-</td>
-</tr>
-<tr>
-<td><b>ServerPack</b></td>
-<td>Skips export entirely (no serverpack file is generated)</td>
-</tr>
-</table>
-
-### Use Cases
-
-The `--no-server` mode is useful when:
-
-- You want to distribute a version of your modpack without server content
-- You need to ensure no server-side content is accidentally included
-- You're creating a specialized client build without server components
-
-> **Note:** The `--no-server` option works independently from the [`export_server_side_projects_to_client`](Config-File.md#export_server_side_projects_to_client) configuration. When `--no-server` is used, it overrides the configuration setting for that export operation.
-
 ## Server-Side Mod Handling
 {id="server-side-mod-handling"}
 
-> Added in version **1.3.4**
+> Added in version **1.4.0**
 
-Pakku provides fine-grained control over how server-side mods are handled in client modpack exports through the [`export_server_side_projects_to_client`](Config-File.md#export_server_side_projects_to_client) configuration option.
+Use the [`export_server_side_projects_to_client`](Config-File.md#export_server_side_projects_to_client) configuration option to control how server-side mods are included in client modpack exports.
 
-> **Important:** This configuration only affects **projects** in the manifest file. Override files (such as the `server-overrides/` directory) are always exported unless the `--no-server` flag is used.
-
-### Behavior by Platform
-
-<table>
-<tr>
-<th>Platform</th>
-<th><code>export_server_side_projects_to_client = false</code></th>
-<th><code>export_server_side_projects_to_client = true</code></th>
-</tr>
-<tr>
-<td><b>CurseForge</b></td>
-<td>Server-side mods are <b>excluded</b> from manifest.json (CurseForge doesn't support environment fields)</td>
-<td>Server-side mods are <b>included</b> in manifest.json (backward compatible)</td>
-</tr>
-<tr>
-<td><b>Modrinth</b></td>
-<td>Server-side mods are <b>included</b> with <code>env.client = "unsupported"</code> (leverages Modrinth's native env field support)</td>
-<td>Server-side mods are <b>included</b> with <code>env.client = "required"</code> (treated as BOTH-side for backward compatibility)</td>
-</tr>
-<tr>
-<td colspan="3"><i>Note: In both cases, <code>server-overrides/</code> directory is exported</i></td>
-</tr>
-</table>
-
-> **Why the difference?**
-> 
-> Modrinth supports native environment fields (`env.client` and `env.server`) that allow precise control over mod loading on different sides. This means Modrinth can include server-side mods in the client modpack while correctly marking them as `client = "unsupported"`, and compatible launchers will skip loading them on the client.
->
-> CurseForge doesn't support environment fields, so the only way to prevent server-side mods from being installed on clients is to exclude them from the manifest entirely.
-
-### Configuration
-
-Set this in your [`pakku.json`](Config-File.md):
-
-```json
-{
-  "export_server_side_projects_to_client": false
-}
-```
-
-- **`false`** (default): Correctly handles server-side mods according to each platform's capabilities
-- **`true`**: Maintains backward compatibility by including all mods
-
-> Existing modpacks (with `lockfile_version: 1`) are automatically migrated to `true` when you first run `pakku export` after upgrading. The lockfile version is then upgraded to `2`.
-
-### Example: Environment Fields in Modrinth
-
-When exporting to Modrinth with `export_server_side_projects_to_client = false`, the generated `modrinth.index.json` will contain:
-
-```json
-{
-  "files": [
-    {
-      "path": "mods/server-only-mod.jar",
-      "env": {
-        "client": "unsupported",
-        "server": "required"
-      }
-    },
-    {
-      "path": "mods/client-mod.jar",
-      "env": {
-        "client": "required",
-        "server": "unsupported"
-      }
-    },
-    {
-      "path": "mods/both-sides-mod.jar",
-      "env": {
-        "client": "required",
-        "server": "required"
-      }
-    }
-  ]
-}
-```
+> For details on how project sides affect exporting behavior, see [Impact on Exporting](Overriding-Projects-Properties.md#impact-on-exporting).
 
 ## How It Works?
 

--- a/docs/topics/Lock-File.md
+++ b/docs/topics/Lock-File.md
@@ -81,18 +81,18 @@ This file is not intended to be modified manually.
             </tr>
             <tr>
                 <td><code>1</code></td>
-                <td>Initial version. Projects created before version 1.3.4.</td>
+                <td>Initial version. Projects created before version 1.4.0.</td>
             </tr>
             <tr>
                 <td><code>2</code></td>
-                <td>Added in version 1.3.4. Indicates that <code>export_server_side_projects_to_client</code> migration has been applied.</td>
+                <td>Added in version 1.4.0. Indicates that <code>export_server_side_projects_to_client</code> migration has been applied.</td>
             </tr>
         </table>
         <p>
             Type: <code>Int</code>
         </p>
         <p>
-            Default: <code>1</code>
+            Default: <code>2</code>
         </p>
     </def>
 </deflist>

--- a/docs/topics/Overriding-Projects-Properties.md
+++ b/docs/topics/Overriding-Projects-Properties.md
@@ -55,18 +55,15 @@ The `side` property determines where a project (mod, resource pack, etc.) can ru
 
 ### Impact on Exporting
 
-> Added in version **1.3.4**
+> Added in version **1.4.0**
 
-The `side` property, combined with the [`export_server_side_projects_to_client`](Config-File.md#export_server_side_projects_to_client) configuration, controls how projects are exported:
+The `side` property affects how projects are exported to client modpacks, controlled by the [`export_server_side_projects_to_client`](Config-File.md#export_server_side_projects_to_client) configuration:
 
-**For CurseForge exports:**
-- When `export_server_side_projects_to_client = false`: `SERVER`-side projects are excluded from the manifest
-- When `export_server_side_projects_to_client = true`: All projects are included
+**When `export_server_side_projects_to_client = false` (default):**
+- **CurseForge**: `SERVER`-side projects are excluded from the manifest
+- **Modrinth**: `SERVER`-side projects are included with `env.client = "unsupported"`
 
-**For Modrinth exports:**
-- All projects are always included
-- `SERVER`-side projects: Set `env.client = "unsupported"` when `export_server_side_projects_to_client = false`, or `env.client = "required"` when `true`
-- `CLIENT`-side projects: Always set `env.client = "required", env.server = "unsupported"`
-- `BOTH`/unspecified projects: Always set `env.client = "required", env.server = "required"`
+**When `export_server_side_projects_to_client = true`:**
+- All projects are included regardless of side (backward compatible behavior)
 
-> See [Exporting a Modpack](Exporting-a-Modpack.md#server-side-mod-handling) for more details on export behavior.
+> **Note:** CurseForge lacks environment field support, so server-side mods must be excluded entirely. Modrinth can include them with proper `env` fields to prevent client loading.


### PR DESCRIPTION
I've streamlined the repetitive explanations.

The `--no-server` directive is already quite clear, so I've removed the redundant details.
The `export_server_side_projects_to_client` description has been moved to the Overriding Project's Properties section.