### PR TITLE
Fix crash on `pakku ls` and `pakku insp`, when project has no file associated

### DIFF
--- a/src/commonMain/kotlin/teksturepako/pakku/api/actions/errors/ActionErrors.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/api/actions/errors/ActionErrors.kt
@@ -214,6 +214,8 @@ data class NoFiles(val project: Project, val lockFile: LockFile) : ActionError()
         "Make sure the project complies these requirements.",
         newlines = true
     )
+
+    override fun shortMessage(arg: String) = "No files attached."
 }
 
 data class VersionsDoNotMatch(val project: Project) : ActionError()

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Insp.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Insp.kt
@@ -19,6 +19,7 @@ import com.github.michaelbull.result.onFailure
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.format
 import kotlinx.datetime.format.DateTimeComponents.Formats.RFC_1123
+import teksturepako.pakku.api.actions.errors.NoFiles
 import teksturepako.pakku.api.actions.errors.ProjNotFound
 import teksturepako.pakku.api.actions.errors.VersionsDoNotMatch
 import teksturepako.pakku.api.data.ConfigFile
@@ -213,10 +214,15 @@ private tailrec fun Terminal.insp(project: Project?, arg: String, lockFile: Lock
             cell(Text("Project Files", overflowWrap = OverflowWrap.BREAK_WORD, whitespace = Whitespace.NORMAL))
             cell(verticalLayout {
                 projectFiles?.asIterable()?.let { cellsFrom(it) }
-                if (project.versionsDoNotMatchAcrossProviders(project.getProviders()))
+                if (!project.hasNoFiles() && project.versionsDoNotMatchAcrossProviders(project.getProviders()))
                 {
                     cell("")
                     cell(this@insp.processShortErrorMsg(VersionsDoNotMatch(project)))
+                }
+                else if (project.hasNoFiles())
+                {
+                    cell("")
+                    cell(this@insp.processShortErrorMsg(NoFiles(project, lockFile)))
                 }
             })
         }

--- a/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Ls.kt
+++ b/src/commonMain/kotlin/teksturepako/pakku/cli/cmd/Ls.kt
@@ -14,6 +14,7 @@ import com.github.ajalt.mordant.terminal.info
 import com.github.michaelbull.result.getOrElse
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
+import teksturepako.pakku.api.actions.errors.NoFiles
 import teksturepako.pakku.api.actions.errors.VersionsDoNotMatch
 import teksturepako.pakku.api.actions.update.updateMultipleProjectsWithFiles
 import teksturepako.pakku.api.data.ConfigFile
@@ -101,11 +102,17 @@ class Ls : CliktCommand()
                     cell(project.type.name)
                     project.side?.let { cell(it.name) }
                 }
-                if (project.versionsDoNotMatchAcrossProviders(project.getProviders()))
+                if (!project.hasNoFiles() && project.versionsDoNotMatchAcrossProviders(project.getProviders()))
                 {
                     row {
                         cell("")
                         cell(terminal.processShortErrorMsg(VersionsDoNotMatch(project)))
+                    }
+                    row()
+                } else if (project.hasNoFiles()) {
+                    row {
+                        cell("")
+                        cell(terminal.processShortErrorMsg(NoFiles(project, lockFile)))
                     }
                     row()
                 }


### PR DESCRIPTION
Closes #122 

* Add check if files are existing
* Add short error `NoFiles` when not
* Add short message to `NoFiles` Error

For reference why I used `!project.hasNoFiles()` instead of `project.hasFiles()` view https://github.com/juraj-hrivnak/Pakku/issues/122#issuecomment-4031594105.