### PR TITLE
Revise fork synchronization and parent layer semantics

### DIFF
--- a/pakku-core/src/main/kotlin/teksturepako/pakku/api/actions/export/Export.kt
+++ b/pakku-core/src/main/kotlin/teksturepako/pakku/api/actions/export/Export.kt
@@ -15,6 +15,7 @@ import teksturepako.pakku.api.data.workingPath
 import teksturepako.pakku.api.overrides.OverridesDeferred
 import teksturepako.pakku.api.overrides.getOverridesAsync
 import teksturepako.pakku.api.overrides.readManualOverrides
+import teksturepako.pakku.api.overrides.ManualOverride
 import teksturepako.pakku.api.platforms.Platform
 import teksturepako.pakku.debug
 import teksturepako.pakku.io.cleanUpDirectory
@@ -34,13 +35,15 @@ suspend fun exportDefaultProfiles(
     platforms: List<Platform>,
     noServer: Boolean = false,
     deps: ExportDeps = defaultExportDeps(),
+    parentOverrides: OverridesDeferred? = null,
+    manualOverrides: Collection<ManualOverride>? = null,
 ): List<Job>
 {
     return export(
         profiles = defaultProfiles,
         onError = { profile, error -> onError(profile, error) },
         onSuccess = { profile, path, duration -> onSuccess(profile, path, duration) },
-        lockFile, configFile, platforms, noServer, deps
+        lockFile, configFile, platforms, noServer, deps, parentOverrides, manualOverrides
     )
 }
 
@@ -53,6 +56,8 @@ suspend fun export(
     platforms: List<Platform>,
     noServer: Boolean = false,
     deps: ExportDeps = defaultExportDeps(),
+    parentOverrides: OverridesDeferred? = null,
+    manualOverrides: Collection<ManualOverride>? = null,
 ): List<Job> = coroutineScope {
     val overrides = getOverridesAsync(configFile)
 
@@ -61,7 +66,7 @@ suspend fun export(
             profile.build(exportRuleScope(lockFile, configFile)).export(
                 onError = { profile, error -> onError(profile, error) },
                 onSuccess = { profile, path, duration -> onSuccess(profile, path, duration) },
-                lockFile, configFile, platforms, overrides, noServer, deps
+                lockFile, configFile, platforms, overrides, noServer, deps, parentOverrides, manualOverrides
             )
         }
     }
@@ -76,6 +81,8 @@ suspend fun ExportProfile.export(
     overrides: OverridesDeferred,
     noServer: Boolean = false,
     deps: ExportDeps = defaultExportDeps(),
+    parentOverrides: OverridesDeferred? = null,
+    manualOverrides: Collection<ManualOverride>? = null,
 )
 {
     if (this.requiresPlatform != null && this.requiresPlatform !in platforms) return
@@ -109,7 +116,7 @@ suspend fun ExportProfile.export(
 
         val results: List<RuleResult> = this.rules
             .filterNotNull()
-            .produceRuleResults(lockFile, configFile, this.name, overrides, noServer, deps)
+            .produceRuleResults(lockFile, configFile, this.name, overrides, noServer, deps, parentOverrides, manualOverrides)
 
         val cachedPaths: List<Path> = results
             .runEffects { error ->
@@ -167,6 +174,7 @@ suspend fun ExportProfile.export(
 suspend fun List<RuleResult>.runEffects(
     onError: suspend (error: ActionError) -> Unit
 ): List<Deferred<Path?>> = coroutineScope {
+    var previousFileAction: Deferred<Path?>? = null
     this@runEffects.mapNotNull { ruleResult ->
         when (val packagingAction = ruleResult.packaging)
         {
@@ -214,8 +222,10 @@ suspend fun List<RuleResult>.runEffects(
             {
                 if (ruleResult.ruleContext !is Finished)
                 {
+                    val predecessor = previousFileAction
                     val action = measureTimedValue {
                         async(Dispatchers.IO) {
+                            predecessor?.await()
                             packagingAction.action().let { (file, error) ->
                                 if (error != null) onError(error)
                                 file
@@ -227,6 +237,7 @@ suspend fun List<RuleResult>.runEffects(
                         debug { println("$ruleResult in ${action.duration}") }
                     }
 
+                    previousFileAction = action.value
                     action.value
                 }
                 else null
@@ -287,7 +298,8 @@ suspend fun List<RuleResult>.runEffectsOnFinished(
  */
 suspend fun List<ExportRule>.produceRuleResults(
     lockFile: LockFile, configFile: ConfigFile, workingSubDir: String, overrides: OverridesDeferred, noServer: Boolean = false,
-    deps: ExportDeps = defaultExportDeps(),
+    deps: ExportDeps = defaultExportDeps(), parentOverrides: OverridesDeferred? = null,
+    manualOverrides: Collection<ManualOverride>? = null,
 ): List<RuleResult> = coroutineScope {
 
     val results = this@produceRuleResults.fold(listOf<Pair<ExportRule, RuleContext>>()) { acc, rule ->
@@ -295,10 +307,10 @@ suspend fun List<ExportRule>.produceRuleResults(
             // Projects
             if (project.export == false) return@mapNotNull null
             rule to RuleContext.ExportingProject(project, lockFile, configFile, workingSubDir, noServer, deps)
-        } + overrides.awaitAll().map { (overridePath, overrideType) ->
+        } + (parentOverrides?.awaitAll().orEmpty() + overrides.awaitAll()).map { source ->
             // Overrides
-            rule to RuleContext.ExportingOverride(overridePath, overrideType, lockFile, configFile, workingSubDir, noServer, deps)
-        } + readManualOverrides(configFile).map { projectOverride ->
+            rule to RuleContext.ExportingOverride(source, lockFile, configFile, workingSubDir, noServer, deps)
+        } + (manualOverrides ?: readManualOverrides(configFile)).map { projectOverride ->
             // Manual overrides
             rule to RuleContext.ExportingManualOverride(projectOverride, lockFile, configFile, workingSubDir, noServer, deps)
         }

--- a/pakku-core/src/main/kotlin/teksturepako/pakku/api/actions/export/RuleContext.kt
+++ b/pakku-core/src/main/kotlin/teksturepako/pakku/api/actions/export/RuleContext.kt
@@ -15,6 +15,7 @@ import teksturepako.pakku.api.data.json
 import teksturepako.pakku.api.data.workingPath
 import teksturepako.pakku.api.overrides.ManualOverride
 import teksturepako.pakku.api.overrides.OverrideType
+import teksturepako.pakku.api.overrides.OverrideSource
 import teksturepako.pakku.api.platforms.Provider
 import teksturepako.pakku.api.projects.Project
 import teksturepako.pakku.io.copyFileTo
@@ -170,8 +171,7 @@ sealed class RuleContext(
 
     /** Rule context representing an 'override'. */
     data class ExportingOverride(
-        val path: String,
-        val type: OverrideType,
+        val source: OverrideSource,
         override val lockFile: LockFile,
         override val configFile: ConfigFile,
         override val workingSubDir: String,
@@ -179,6 +179,8 @@ sealed class RuleContext(
         override val deps: ExportDeps = defaultExportDeps(),
     ) : RuleContext(workingSubDir, lockFile, configFile, noServer, deps)
     {
+        val path get() = source.path
+        val type get() = source.type
         fun export(
             overridesDir: String? = type.folderName,
             allowedTypes: Set<OverrideType>? = null
@@ -186,7 +188,7 @@ sealed class RuleContext(
         {
             if (allowedTypes != null && type !in allowedTypes) return ignore()
 
-            val inputPath = Path(workingPath, path)
+            val inputPath = source.root.resolve(path)
             val outputPath = overridesDir?.let { getPath(it, path) } ?: getPath(path)
 
             val message = "export $type '$inputPath' to '$outputPath'"

--- a/pakku-core/src/main/kotlin/teksturepako/pakku/api/actions/remote/SyncRemoteDirectory.kt
+++ b/pakku-core/src/main/kotlin/teksturepako/pakku/api/actions/remote/SyncRemoteDirectory.kt
@@ -38,12 +38,12 @@ suspend fun syncRemoteDirectory(
 
     val overrides = getOverridesAsyncFrom(Dirs.remoteDir, configFile).awaitAll()
 
-    val error = overrides.map { (overridePath, overrideType) ->
+    val error = overrides.map { source ->
         async(Dispatchers.IO) {
-            if (allowedTypes != null && overrideType !in allowedTypes) return@async null
+            if (allowedTypes != null && source.type !in allowedTypes) return@async null
 
-            val inputPath = Path(Dirs.remoteDir.pathString, overridePath)
-            val outputPath = Path(workingPath, overridePath)
+            val inputPath = source.root.resolve(source.path)
+            val outputPath = Path(workingPath, source.path)
 
             inputPath.copyRecursivelyTo(outputPath, onSync, cleanUp = forceCleanUp)
         }

--- a/pakku-core/src/main/kotlin/teksturepako/pakku/api/data/LockFile.kt
+++ b/pakku-core/src/main/kotlin/teksturepako/pakku/api/data/LockFile.kt
@@ -275,9 +275,8 @@ data class LockFile(
     /** Merge a parent lock file with the local fork layer. */
     fun mergedWithLocal(localLockFile: LockFile, localConfigFile: ConfigFile): LockFile
     {
-        val localSlugs = localLockFile.projects.flatMap { it.slug.values }.toSet()
         val keptParentProjects = this.projects
-            .filterNot { parentProject -> parentProject.slug.values.any { it in localSlugs } }
+            .filterNot { parentProject -> localLockFile.projects.any { parentProject isAlmostTheSameAs it } }
             .filterNot { parentProject ->
                 parentProject.slug.values.any { it in localConfigFile.excludes }
                         || parentProject.name.values.any { it in localConfigFile.excludes }

--- a/pakku-core/src/main/kotlin/teksturepako/pakku/api/overrides/Overrides.kt
+++ b/pakku-core/src/main/kotlin/teksturepako/pakku/api/overrides/Overrides.kt
@@ -7,23 +7,11 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import teksturepako.pakku.api.actions.errors.ActionError
 import teksturepako.pakku.api.data.ConfigFile
+import teksturepako.pakku.api.data.workingPath
 import java.nio.file.Path
 
-suspend fun getOverridesAsync(configFile: ConfigFile): OverridesDeferred = coroutineScope {
-    val overrides: Deferred<List<Result<String, ActionError>>> = async {
-        configFile.getAllOverrides()
-    }
-
-    val serverOverrides: Deferred<List<Result<String, ActionError>>> = async {
-        configFile.getAllServerOverrides()
-    }
-
-    val clientOverrides: Deferred<List<Result<String, ActionError>>> = async {
-        configFile.getAllClientOverrides()
-    }
-
-    return@coroutineScope OverridesDeferred(overrides, serverOverrides, clientOverrides)
-}
+suspend fun getOverridesAsync(configFile: ConfigFile): OverridesDeferred =
+    getOverridesAsyncFrom(Path.of(workingPath), configFile)
 
 suspend fun getOverridesAsyncFrom(path: Path, configFile: ConfigFile): OverridesDeferred = coroutineScope {
     val overrides: Deferred<List<Result<String, ActionError>>> = async {
@@ -38,16 +26,17 @@ suspend fun getOverridesAsyncFrom(path: Path, configFile: ConfigFile): Overrides
         configFile.getAllClientOverridesFrom(path)
     }
 
-    return@coroutineScope OverridesDeferred(overrides, serverOverrides, clientOverrides)
+    return@coroutineScope OverridesDeferred(path, overrides, serverOverrides, clientOverrides)
 }
 
 data class OverridesDeferred(
+    val root: Path,
     val overrides: Deferred<List<Result<String, ActionError>>>,
     val serverOverrides: Deferred<List<Result<String, ActionError>>>,
     val clientOverrides: Deferred<List<Result<String, ActionError>>>,
 )
 {
-    suspend fun awaitAll(): List<Pair<String, OverrideType>>
+    suspend fun awaitAll(): List<OverrideSource>
     {
         val results = listOf(
             overrides.await() to OverrideType.OVERRIDE,
@@ -58,8 +47,10 @@ data class OverridesDeferred(
         return results.flatMap {
             it.first.mapNotNull { result ->
                 val pathString = result.get() ?: return@mapNotNull null
-                pathString to it.second
+                OverrideSource(root, pathString, it.second)
             }
         }
     }
 }
+
+data class OverrideSource(val root: Path, val path: String, val type: OverrideType)

--- a/pakku-core/src/main/kotlin/teksturepako/pakku/cli/cmd/Export.kt
+++ b/pakku-core/src/main/kotlin/teksturepako/pakku/cli/cmd/Export.kt
@@ -23,6 +23,9 @@ import teksturepako.pakku.api.data.LockFile
 import teksturepako.pakku.api.data.parentConfigFilePath
 import teksturepako.pakku.api.data.parentLockFilePath
 import teksturepako.pakku.api.data.sha256
+import teksturepako.pakku.api.overrides.getOverridesAsyncFrom
+import teksturepako.pakku.api.overrides.readManualOverrides
+import teksturepako.pakku.api.overrides.readManualOverridesFrom
 import teksturepako.pakku.api.platforms.CurseForge
 import teksturepako.pakku.api.platforms.Platform
 import teksturepako.pakku.cli.arg.promptForCurseForgeApiKey
@@ -68,6 +71,8 @@ class Export : CliktCommand()
             terminal.pSuccess("[Migration] Upgraded lockfile to version 2. Added 'export_server_side_projects_to_client=true' for backward compatibility.")
         }
 
+        var parentOverrides: teksturepako.pakku.api.overrides.OverridesDeferred? = null
+        var forkManualOverrides: Collection<teksturepako.pakku.api.overrides.ManualOverride>? = null
         val exportLockFile = if (migratedConfig.parent != null)
         {
             val parentLockPath = parentLockFilePath()
@@ -102,6 +107,29 @@ class Export : CliktCommand()
                 echo()
                 return@runBlocking
             }
+
+            val parentConfig = parentConfigPath?.let { path ->
+                ConfigFile.readToResultFrom(path).getOrElse {
+                    terminal.pError(it)
+                    echo()
+                    return@runBlocking
+                }
+            }
+            if (parentConfig != null)
+            {
+                parentLockFile.inheritConfig(parentConfig)
+                val localPaths = migratedConfig.paths.toMap()
+                migratedConfig.paths.clear()
+                migratedConfig.paths.putAll(parentConfig.paths)
+                migratedConfig.paths.putAll(localPaths)
+                parentOverrides = getOverridesAsyncFrom(parentLockPath.parent, parentConfig)
+            }
+
+            val parentManual = readManualOverridesFrom(parentLockPath.parent, parentConfig)
+            val localManual = readManualOverrides(migratedConfig)
+            forkManualOverrides = (parentManual + localManual)
+                .associateBy { it.type to it.relativeOutputPath.normalize() }
+                .values
 
             parentLockFile.mergedWithLocal(migratedLockFile, migratedConfig)
         }
@@ -140,7 +168,8 @@ class Export : CliktCommand()
 
                 terminal.pSuccess("[${profile.name} profile] exported to '$file' ($fileSize) in ${duration.shortForm()}")
             },
-            exportLockFile, migratedConfig, platforms, noServer
+            exportLockFile, migratedConfig, platforms, noServer,
+            parentOverrides = parentOverrides, manualOverrides = forkManualOverrides
         ).joinAll()
 
         progressBar.clear()

--- a/pakku-core/src/main/kotlin/teksturepako/pakku/cli/cmd/Fork.kt
+++ b/pakku-core/src/main/kotlin/teksturepako/pakku/cli/cmd/Fork.kt
@@ -25,14 +25,14 @@ import teksturepako.pakku.cli.ui.pDanger
 import teksturepako.pakku.cli.ui.pError
 import teksturepako.pakku.cli.ui.pMsg
 import teksturepako.pakku.cli.ui.pSuccess
-import teksturepako.pakku.integration.git.gitFetchCheckout
 import teksturepako.pakku.integration.git.gitClone
 import teksturepako.pakku.integration.git.gitHeadCommit
+import teksturepako.pakku.integration.git.gitHeadTags
 import teksturepako.pakku.integration.git.gitIsClean
 import teksturepako.pakku.integration.git.gitRefType
 import teksturepako.pakku.integration.git.gitRemoteUrl
 import teksturepako.pakku.integration.git.gitSetRemoteUrl
-import teksturepako.pakku.integration.git.gitUpdate
+import teksturepako.pakku.integration.git.gitSyncRef
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.Path
 import kotlin.io.path.createFile
@@ -44,6 +44,8 @@ import kotlin.io.path.notExists
 import kotlin.io.path.pathString
 import kotlin.io.path.readText
 import kotlin.io.path.writeText
+import kotlin.io.path.moveTo
+import java.util.UUID
 
 class Fork : CliktCommand()
 {
@@ -68,8 +70,9 @@ private class ForkInit : CliktCommand(name = "init")
     private val refTypeOpt: String? by option("--ref-type").choice("branch", "tag", "commit").help("Type of ref to track")
     private val remoteOpt: String by option("--remote").help("Remote name").default("origin")
 
+    @OptIn(ExperimentalPathApi::class)
     override fun run(): Unit = runBlocking {
-        val config = ConfigFile.readOrNull() ?: ConfigFile()
+        val config = readConfigSafely() ?: return@runBlocking
         if (config.parent != null)
         {
             terminal.pDanger("Parent already configured: ${config.parent?.id}")
@@ -120,19 +123,33 @@ private class ForkInit : CliktCommand(name = "init")
         }
 
         val cloneUrl = fromPathOpt ?: sourceUrl
+        val cloneDir = parentDir.resolveSibling("${parentDir.fileName}.init-${UUID.randomUUID()}")
         terminal.pMsg("Cloning parent repository '$sourceUrl'")
-        gitClone(cloneUrl, parentDir, refNameOpt) { _, _ -> }?.let {
+        val requestedRefType = refTypeOpt?.uppercase()?.let { ConfigFile.RefType.valueOf(it) }
+            ?: refNameOpt.takeIf { it.matches(Regex("[0-9a-fA-F]{7,40}")) }?.let { ConfigFile.RefType.COMMIT }
+        gitClone(cloneUrl, cloneDir, if (requestedRefType == ConfigFile.RefType.COMMIT) null else refNameOpt) { _, _ -> }?.let {
+            if (cloneDir.exists()) cloneDir.deleteRecursively()
             terminal.pError(it)
             return@runBlocking
         }
-        if (fromPathOpt != null) gitSetRemoteUrl(parentDir, remoteOpt, sourceUrl)
+        if (fromPathOpt != null) gitSetRemoteUrl(cloneDir, "origin", sourceUrl)
+        if (requestedRefType == ConfigFile.RefType.COMMIT)
+        {
+            gitSyncRef(cloneDir, remoteOpt, refNameOpt, ConfigFile.RefType.COMMIT) { _, _ -> }?.let {
+                cloneDir.deleteRecursively()
+                terminal.pError(it)
+                return@runBlocking
+            }
+        }
 
-        val commit = runCatching { gitHeadCommit(parentDir) }.getOrElse {
+        val commit = runCatching { gitHeadCommit(cloneDir) }.getOrElse {
+            cloneDir.deleteRecursively()
             terminal.pDanger("Could not determine HEAD commit of parent repository")
             return@runBlocking
         }
         if (!commit.matches(Regex("[0-9a-fA-F]{40}")))
         {
+            cloneDir.deleteRecursively()
             terminal.pDanger("Invalid HEAD commit of parent repository: $commit")
             return@runBlocking
         }
@@ -140,11 +157,16 @@ private class ForkInit : CliktCommand(name = "init")
             id = sourceUrl,
             version = commit.take(8),
             ref = refNameOpt,
-            refType = refTypeOpt?.uppercase()?.let { ConfigFile.RefType.valueOf(it) } ?: gitRefType(parentDir, refNameOpt),
-            remoteName = remoteOpt
+            refType = requestedRefType ?: gitRefType(cloneDir, refNameOpt),
+            remoteName = "origin"
         )
+        cloneDir.moveTo(parentDir)
         updateParentHashes(config)
-        config.write()
+        config.write()?.let {
+            parentDir.deleteRecursively()
+            terminal.pError(it)
+            return@runBlocking
+        }
         addParentToGitignore()
 
         terminal.pSuccess("Fork initialized")
@@ -157,8 +179,9 @@ private class ForkSync : CliktCommand(name = "sync")
 {
     override fun help(context: Context) = "Sync the immutable parent checkout"
 
+    @OptIn(ExperimentalPathApi::class)
     override fun run(): Unit = runBlocking {
-        val config = ConfigFile.readOrNull() ?: ConfigFile()
+        val config = readConfigSafely() ?: return@runBlocking
         val parent = config.parent ?: run {
             terminal.pDanger("No parent configured. Run 'pakku fork init' first.")
             return@runBlocking
@@ -167,19 +190,23 @@ private class ForkSync : CliktCommand(name = "sync")
         if (Dirs.parentDir.notExists())
         {
             terminal.pMsg("Parent repository not found. Cloning...")
-            gitClone(parent.id, Dirs.parentDir, parent.ref) { _, _ -> }?.let {
+            val cloneDir = Dirs.parentDir.resolveSibling("${Dirs.parentDir.fileName}.sync-${UUID.randomUUID()}")
+            gitClone(parent.id, cloneDir, if (parent.refType == ConfigFile.RefType.COMMIT) null else parent.ref) { _, _ -> }?.let {
+                if (cloneDir.exists()) cloneDir.deleteRecursively()
                 terminal.pError(it)
                 return@runBlocking
             }
+            gitSyncRef(cloneDir, parent.remoteName, parent.ref, parent.refType) { _, _ -> }?.let {
+                cloneDir.deleteRecursively()
+                terminal.pError(it)
+                return@runBlocking
+            }
+            cloneDir.moveTo(Dirs.parentDir)
         }
         else
         {
             terminal.pMsg("Fetching parent updates")
-            val error = when (parent.refType)
-            {
-                ConfigFile.RefType.BRANCH -> gitUpdate(Dirs.parentDir, parent.ref) { _, _ -> }
-                ConfigFile.RefType.TAG, ConfigFile.RefType.COMMIT -> gitFetchCheckout(Dirs.parentDir, parent.ref) { _, _ -> }
-            }
+            val error = gitSyncRef(Dirs.parentDir, parent.remoteName, parent.ref, parent.refType) { _, _ -> }
             error?.let {
                 terminal.pError(it)
                 return@runBlocking
@@ -197,7 +224,7 @@ private class ForkSync : CliktCommand(name = "sync")
         }
         config.parent?.version = commit.take(8)
         updateParentHashes(config)
-        config.write()
+        config.write()?.let { terminal.pError(it); return@runBlocking }
 
         terminal.pSuccess("Parent sync complete")
         terminal.pMsg("Commit: ${commit.take(8)}")
@@ -210,7 +237,7 @@ private class ForkShow : CliktCommand(name = "show")
 
     override fun run()
     {
-        val config = ConfigFile.readOrNull() ?: ConfigFile()
+        val config = readConfigSafely() ?: return
         val parent = config.parent ?: run {
             terminal.pMsg("No fork configured.")
             return
@@ -220,6 +247,8 @@ private class ForkShow : CliktCommand(name = "show")
         terminal.pMsg("Ref: ${parent.ref} (${parent.refType.name.lowercase()})")
         terminal.pMsg("Remote: ${parent.remoteName}")
         terminal.pMsg("Last synced commit: ${parent.version ?: "never synced"}")
+        runCatching { gitHeadTags(Dirs.parentDir) }.getOrDefault(emptyList()).takeIf { it.isNotEmpty() }
+            ?.let { terminal.pMsg("Upstream tag${if (it.size == 1) "" else "s"}: ${it.joinToString()}") }
         config.parentLockHash?.let { terminal.pMsg("Parent lock hash: $it") }
         if (config.excludes.isNotEmpty()) terminal.pMsg("Excluded projects: ${config.excludes.joinToString()}")
     }
@@ -231,7 +260,7 @@ private class ForkUnset : CliktCommand(name = "unset")
 
     @OptIn(ExperimentalPathApi::class)
     override fun run(): Unit = runBlocking {
-        val config = ConfigFile.readOrNull() ?: ConfigFile()
+        val config = readConfigSafely() ?: return@runBlocking
         if (config.parent == null)
         {
             terminal.pMsg("No fork configured.")
@@ -239,12 +268,12 @@ private class ForkUnset : CliktCommand(name = "unset")
         }
         if (!terminal.ynPrompt("Do you really want to remove the fork parent?")) return@runBlocking
 
-        if (Dirs.parentDir.exists()) Dirs.parentDir.deleteRecursively()
         config.parent = null
         config.parentLockHash = null
         config.parentConfigHash = null
         config.excludes.clear()
-        config.write()
+        config.write()?.let { terminal.pError(it); return@runBlocking }
+        if (Dirs.parentDir.exists()) Dirs.parentDir.deleteRecursively()
         terminal.pDanger("Fork configuration removed")
     }
 }
@@ -255,7 +284,7 @@ private class ForkPromote : CliktCommand(name = "promote")
     private val projectsArgs: List<String> by argument("project").multiple(required = true)
 
     override fun run(): Unit = runBlocking {
-        val config = ConfigFile.readOrNull() ?: ConfigFile()
+        val config = readConfigSafely() ?: return@runBlocking
         if (config.parent == null)
         {
             terminal.pDanger("No parent configured. Run 'pakku fork init' first.")
@@ -265,8 +294,14 @@ private class ForkPromote : CliktCommand(name = "promote")
             terminal.pDanger("Parent lock file not found. Run 'pakku fork sync' first.")
             return@runBlocking
         }
-        val parentLock = LockFile.readOrNewFrom(parentLockPath).getOrElse { LockFile() }
-        val localLock = LockFile.readOrNew().getOrElse { LockFile() }
+        val parentLock = LockFile.readOrNewFrom(parentLockPath).getOrElse {
+            terminal.pError(it)
+            return@runBlocking
+        }
+        val localLock = LockFile.readOrNew().getOrElse {
+            terminal.pError(it)
+            return@runBlocking
+        }
         val missing = mutableListOf<String>()
 
         projectsArgs.forEach { input ->
@@ -280,7 +315,7 @@ private class ForkPromote : CliktCommand(name = "promote")
             return@runBlocking
         }
 
-        localLock.write()
+        localLock.write()?.let { terminal.pError(it); return@runBlocking }
         terminal.pSuccess("Promoted ${projectsArgs.size} project(s) to the local lock file")
     }
 }
@@ -291,9 +326,10 @@ private class ForkExclude : CliktCommand(name = "exclude")
     private val projectsArgs: List<String> by argument("project").multiple(required = true)
 
     override fun run(): Unit = runBlocking {
-        val config = ConfigFile.readOrNull() ?: ConfigFile()
+        val config = readConfigSafely() ?: return@runBlocking
+        if (config.parent == null) { terminal.pDanger("No parent configured."); return@runBlocking }
         config.excludes.addAll(projectsArgs)
-        config.write()
+        config.write()?.let { terminal.pError(it); return@runBlocking }
         terminal.pSuccess("Excluded ${projectsArgs.size} parent project(s)")
     }
 }
@@ -304,9 +340,10 @@ private class ForkInclude : CliktCommand(name = "include")
     private val projectsArgs: List<String> by argument("project").multiple(required = true)
 
     override fun run(): Unit = runBlocking {
-        val config = ConfigFile.readOrNull() ?: ConfigFile()
+        val config = readConfigSafely() ?: return@runBlocking
+        if (config.parent == null) { terminal.pDanger("No parent configured."); return@runBlocking }
         config.excludes.removeAll(projectsArgs.toSet())
-        config.write()
+        config.write()?.let { terminal.pError(it); return@runBlocking }
         terminal.pSuccess("Re-included ${projectsArgs.size} parent project(s)")
     }
 }
@@ -315,6 +352,14 @@ private fun updateParentHashes(config: ConfigFile)
 {
     config.parentLockHash = parentLockFilePath()?.let { sha256(it) }
     config.parentConfigHash = parentConfigFilePath()?.let { sha256(it) }
+}
+
+private fun CliktCommand.readConfigSafely(): ConfigFile?
+{
+    return ConfigFile.readOrNew().getOrElse {
+        terminal.pError(it)
+        null
+    }
 }
 
 private fun addParentToGitignore()

--- a/pakku-core/src/main/kotlin/teksturepako/pakku/integration/git/GitUpdate.kt
+++ b/pakku-core/src/main/kotlin/teksturepako/pakku/integration/git/GitUpdate.kt
@@ -152,3 +152,58 @@ fun gitRefType(dir: Path, ref: String): ConfigFile.RefType =
             else -> ConfigFile.RefType.BRANCH
         }
     }
+
+suspend fun gitSyncRef(
+    dir: Path,
+    remoteName: String,
+    ref: String,
+    refType: ConfigFile.RefType,
+    onProgress: (taskName: String?, percentDone: Int) -> Unit,
+): ActionError? = coroutineScope {
+    val (progressMonitor, outputStream, writer) = pakkuGitProgressMonitor(onProgress)
+    try
+    {
+        Git.open(dir.toFile()).use { git ->
+            git.clean().setForce(true).setCleanDirectories(true).call()
+            val configuredRemote = git.repository.config.getString("remote", remoteName, "url")
+                ?.let { remoteName } ?: Constants.DEFAULT_REMOTE_NAME
+            git.fetch().setRemote(configuredRemote).setProgressMonitorIfPossible(progressMonitor).call()
+
+            val target = when (refType)
+            {
+                ConfigFile.RefType.BRANCH -> "refs/remotes/$configuredRemote/$ref"
+                ConfigFile.RefType.TAG -> "refs/tags/$ref"
+                ConfigFile.RefType.COMMIT -> ref
+            }
+            val objectId = git.repository.resolve(target)
+                ?: return@coroutineScope GitUpdateError(dir, "Ref '$ref' was not fetched")
+
+            git.checkout().setForced(true).setName(objectId.name).call()
+        }
+    }
+    catch (e: Exception)
+    {
+        debug { e.printStackTrace() }
+        return@coroutineScope GitUpdateError(dir, e.message)
+    }
+    finally
+    {
+        withContext(Dispatchers.IO) {
+            writer.close()
+            outputStream.close()
+        }
+    }
+    null
+}
+
+fun gitHeadTags(dir: Path): List<String> = Git.open(dir.toFile()).use { git ->
+    val repository = git.repository
+    val head = repository.resolve(Constants.HEAD) ?: return@use emptyList()
+    repository.refDatabase.getRefsByPrefix(Constants.R_TAGS)
+        .filter { ref ->
+            val peeled = repository.refDatabase.peel(ref)
+            (peeled.peeledObjectId ?: peeled.objectId) == head
+        }
+        .map { it.name.removePrefix(Constants.R_TAGS) }
+        .sorted()
+}

--- a/pakku-core/src/test/kotlin/teksturepako/pakku/api/data/ForkTest.kt
+++ b/pakku-core/src/test/kotlin/teksturepako/pakku/api/data/ForkTest.kt
@@ -1,0 +1,63 @@
+package teksturepako.pakku.api.data
+
+import kotlinx.coroutines.runBlocking
+import org.eclipse.jgit.api.Git
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.isEqualTo
+import teksturepako.pakku.PakkuTest
+import teksturepako.pakku.api.overrides.getOverridesAsyncFrom
+import teksturepako.pakku.api.projects.Project
+import teksturepako.pakku.api.projects.ProjectType
+import teksturepako.pakku.integration.git.gitHeadTags
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.Test
+
+class ForkTest : PakkuTest()
+{
+    @Test
+    fun `local project replaces parent through stable project identity`()
+    {
+        val parent = LockFile().apply { add(project("shared-id", "parent-slug")) }
+        val localProject = project("shared-id", "local-slug")
+        val local = LockFile().apply { add(localProject) }
+
+        expectThat(parent.mergedWithLocal(local, ConfigFile()).getAllProjects())
+            .containsExactly(localProject)
+    }
+
+    @Test
+    fun `parent override paths retain the parent checkout as their root`(): Unit = runBlocking {
+        val parent = testPath("parent").also { it.createDirectories() }
+        parent.resolve("config").also { it.createDirectories() }.resolve("base.cfg").writeText("base")
+        val config = ConfigFile().apply { addOverride("config") }
+
+        val source = getOverridesAsyncFrom(parent, config).awaitAll().single()
+
+        expectThat(source.root).isEqualTo(parent)
+        expectThat(source.path).isEqualTo("config/base.cfg")
+    }
+
+    @Test
+    fun `head tags include annotated tags resolving to head`()
+    {
+        val repository = testPath("tagged").also { it.createDirectories() }
+        Git.init().setDirectory(repository.toFile()).call().use { git ->
+            repository.resolve("file.txt").writeText("content")
+            git.add().addFilepattern("file.txt").call()
+            git.commit().setMessage("initial").setAuthor("Pakku", "pakku@example.invalid").call()
+            git.tag().setName("v1.0.0").setMessage("release").call()
+        }
+
+        expectThat(gitHeadTags(repository)).containsExactly("v1.0.0")
+    }
+
+    private fun project(id: String, slug: String) = Project(
+        type = ProjectType.MOD,
+        id = mutableMapOf("provider" to id),
+        name = mutableMapOf("provider" to slug),
+        slug = mutableMapOf("provider" to slug),
+        files = mutableSetOf(),
+    )
+}


### PR DESCRIPTION
Looks like the previous #136 left out a few important things around the handing of *config files* from the parent. I had not noticed this earlier (sorry!) because my modpacks explicitly override the parent's config but while forking a new modpack I've noticed they're actually left out. Thus, this pull requests changes  how overrides and manual overrides are handled throughout the export and fork processes and streamline parent/child project semantics with better override path management.

Noteworthy changes:

- The export pipeline now supports passing parent overrides and manual overrides through all relevant functions. This ensures that parent project data is merged *correctly*, and even prioritized during export. I.e., I fixed the config bug.

- The `OverridesDeferred` structure now includes a `root` path, and override entries are represented by the new `OverrideSource` data class. This is more of a correctness change than a bugfix, but it helps ensure correct file resolution regardless of override's origin. Better safe than sorry.

- All code handling overrides and manual overrides now uses the new `OverrideSource` abstraction, including export rule contexts and remote sync actions. This guarantees sequential execution of file actions and makes Pakku await the previous file action before starting the next to prevent race conditions regarding malformed manifest cases.

- `pakku parent show` now matches upstream tags with refs if available. This is a cosmetic-ish change, but it provides more information to users and it's relatively cheap since we already have the parent checked out.

There are a few more changes present in the diff, but those are the important ones.